### PR TITLE
Fix bug: Autocomplete doesn't clear correctly

### DIFF
--- a/components/Autocomplete/Autocomplete.js
+++ b/components/Autocomplete/Autocomplete.js
@@ -186,7 +186,7 @@ export const getSimpleValue = (options, value, valueKey, isMultiSelection) => {
   const result = isMultiSelection
     ? innerJoin((o, v) => o[valueKey] === v, flattenOptions, value)
     : find(propEq(valueKey, value), flattenOptions)
-  return result;
+  return result || null;
 }
 
 function DropdownIndicator() {


### PR DESCRIPTION
When sent an undefined value, the _getSimpleValue_ function returns undefined, which doesn't clear the Autocomplete (the old value is still shown).
This might be caused by a react-select bug:
https://github.com/JedWatson/react-select/issues/3066

We solve it by returning **null**, instead of undefined, in _getSimpleValue()_.
