### PR TITLE
Add disableBackdropClick, disableEscapeKeyDown functionalities for CustomDialog and DialogDisplay

### DIFF
--- a/__tests__/CustomDialog/__snapshots__/CustomDialog.test.js.snap
+++ b/__tests__/CustomDialog/__snapshots__/CustomDialog.test.js.snap
@@ -32,7 +32,7 @@ exports[`CustomDialog snapshot 1`] = `
     fullScreen={false}
     fullWidth={true}
     maxWidth="md"
-    onClose={[MockFunction]}
+    onClose={[Function]}
     open={true}
   >
     <ForwardRef(Dialog)
@@ -65,7 +65,7 @@ exports[`CustomDialog snapshot 1`] = `
       fullScreen={false}
       fullWidth={true}
       maxWidth="md"
-      onClose={[MockFunction]}
+      onClose={[Function]}
       open={true}
     >
       <ForwardRef(Modal)
@@ -395,7 +395,7 @@ exports[`CustomDialog snapshot 1`] = `
         className="MuiDialog-root"
         closeAfterTransition={true}
         disableEscapeKeyDown={false}
-        onClose={[MockFunction]}
+        onClose={[Function]}
         open={true}
       >
         <ForwardRef(Portal)

--- a/__tests__/DialogDisplay/__snapshots__/DialogDisplay.test.js.snap
+++ b/__tests__/DialogDisplay/__snapshots__/DialogDisplay.test.js.snap
@@ -20,7 +20,7 @@ exports[`DialogDisplay snapshot 1`] = `
     }
     aria-labelledby="id-dialog-display-title"
     maxWidth="xl"
-    onClose={[MockFunction]}
+    onClose={[Function]}
     open={true}
   >
     <ForwardRef(Dialog)
@@ -50,7 +50,7 @@ exports[`DialogDisplay snapshot 1`] = `
         }
       }
       maxWidth="xl"
-      onClose={[MockFunction]}
+      onClose={[Function]}
       open={true}
     >
       <ForwardRef(Modal)
@@ -380,7 +380,7 @@ exports[`DialogDisplay snapshot 1`] = `
         className="MuiDialog-root"
         closeAfterTransition={true}
         disableEscapeKeyDown={false}
-        onClose={[MockFunction]}
+        onClose={[Function]}
         open={true}
       >
         <ForwardRef(Portal)

--- a/components/CustomDialog/CustomDialog.d.ts
+++ b/components/CustomDialog/CustomDialog.d.ts
@@ -104,6 +104,16 @@ export interface CustomDialogProps extends Omit<DialogProps, 'open' | 'fullWidth
      * The value of the overflowY CSS property
      */
     overflowY?: "scroll" | "hidden" | "visible" | "auto"
+    /**
+     * @default false
+     * If true, clicking the backdrop will not fire the onClose callback.
+     */
+    disableBackdropClick?: boolean
+    /**
+     * @default false
+     * If true, hitting escape will not fire the onClose callback.
+     */
+    disableEscapeKeyDown?: boolean
 }
 /**
  *

--- a/components/CustomDialog/CustomDialog.js
+++ b/components/CustomDialog/CustomDialog.js
@@ -46,17 +46,12 @@ const CustomDialog = ({
     [classes[overflowY]]: overflowY
   });
 
-  const handleActionClose = useCallback(
-    event => onClose(event, "closeActionClick"),
-    [onClose]
-  );
-
   const handleClose = useCallback(
     (event, reason) => {
       if (disableBackdropClick && reason === "backdropClick") return;
       if (disableEscapeKeyDown && reason === "escapeKeyDown") return;
 
-      onClose();
+      onClose(event, reason ? reason : "closeActionClick");
     },
     [disableBackdropClick, disableEscapeKeyDown, onClose]
   );
@@ -120,7 +115,7 @@ const CustomDialog = ({
                 right
                 size={buttonSize}
                 color={buttonColor}
-                onClick={handleActionClose}
+                onClick={handleClose}
               >
                 {textDialogNo}
               </Button>

--- a/components/CustomDialog/CustomDialog.js
+++ b/components/CustomDialog/CustomDialog.js
@@ -18,8 +18,27 @@ import cx from "classnames";
 
 const useStyles = makeStyles(customDialogStyle);
 
-const CustomDialog = ({ id, open, title, content, textContent, onYes, onClose, buttonColor, buttonSize, showActions, fullWidth,
-  maxWidth, textDialogYes, textDialogNo, showX, overflowY, ...rest }) => {
+const CustomDialog = ({
+  id,
+  open,
+  title,
+  content,
+  textContent,
+  onYes,
+  onClose,
+  buttonColor,
+  buttonSize,
+  showActions,
+  fullWidth,
+  maxWidth,
+  textDialogYes,
+  textDialogNo,
+  showX,
+  overflowY,
+  disableBackdropClick,
+  disableEscapeKeyDown,
+  ...rest
+}) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const classes = useStyles();
@@ -27,7 +46,20 @@ const CustomDialog = ({ id, open, title, content, textContent, onYes, onClose, b
     [classes[overflowY]]: overflowY
   });
 
-  const handleActionClose = useCallback(event => onClose(event, 'closeActionClick'), [onClose])
+  const handleActionClose = useCallback(
+    event => onClose(event, "closeActionClick"),
+    [onClose]
+  );
+
+  const handleClose = useCallback(
+    (event, reason) => {
+      if (disableBackdropClick && reason === "backdropClick") return;
+      if (disableEscapeKeyDown && reason === "escapeKeyDown") return;
+
+      onClose();
+    },
+    [disableBackdropClick, disableEscapeKeyDown, onClose]
+  );
 
   return (
     <Dialog
@@ -35,7 +67,7 @@ const CustomDialog = ({ id, open, title, content, textContent, onYes, onClose, b
         className: classes.paper
       }}
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       aria-labelledby={`${id}-dialog-yes-no-title`}
       aria-describedby={`${id}-dialog-yes-no-description`}
       maxWidth={maxWidth}
@@ -43,10 +75,7 @@ const CustomDialog = ({ id, open, title, content, textContent, onYes, onClose, b
       fullWidth={fullWidth}
       {...rest}
     >
-      <DialogTitle
-        id={`${id}-dialog-yes-no-title`}
-        className={classes.text}
-      >
+      <DialogTitle id={`${id}-dialog-yes-no-title`} className={classes.text}>
         {title}
         {showX && (
           <IconButton
@@ -70,7 +99,13 @@ const CustomDialog = ({ id, open, title, content, textContent, onYes, onClose, b
         <Grid item lg={12}>
           {content}
         </Grid>
-        <Grid item container justifyContent="flex-end" alignItems="center" lg={12}>
+        <Grid
+          item
+          container
+          justifyContent="flex-end"
+          alignItems="center"
+          lg={12}
+        >
           {showActions && (
             <>
               <Button
@@ -194,7 +229,15 @@ CustomDialog.propTypes = {
   /**
    * the value of the overflowY CSS property
    */
-  overflowY: PropTypes.oneOf(["scroll", "hidden", "visible", "auto"])
+  overflowY: PropTypes.oneOf(["scroll", "hidden", "visible", "auto"]),
+  /**
+   * If true, clicking the backdrop will not fire the onClose callback.
+   */
+  disableBackdropClick: PropTypes.bool,
+  /**
+   * If true, hitting escape will not fire the onClose callback.
+   */
+  disableEscapeKeyDown: PropTypes.bool
 };
 
 export default CustomDialog;

--- a/components/DialogDisplay/DialogDisplay.d.ts
+++ b/components/DialogDisplay/DialogDisplay.d.ts
@@ -42,7 +42,17 @@ export interface DialogDisplayProps extends Omit<DialogProps, 'open' | 'onClose'
     /**
      * The value of the overflowY CSS property
      */
-    overflowY?: "scroll" | "hidden" | "visible" | "auto"
+    overflowY?: "scroll" | "hidden" | "visible" | "auto",
+    /**
+     * @default false
+     * If true, clicking the backdrop will not fire the onClose callback.
+     */
+    disableBackdropClick?: boolean
+    /**
+     * @default false
+     * If true, hitting escape will not fire the onClose callback.
+     */
+    disableEscapeKeyDown?: boolean
 }
 /**
  *

--- a/components/DialogDisplay/DialogDisplay.js
+++ b/components/DialogDisplay/DialogDisplay.js
@@ -31,17 +31,12 @@ const DialogDisplay = ({
     [classes[overflowY]]: overflowY
   });
 
-  const handleActionClose = useCallback(
-    event => onClose(event, "closeActionClick"),
-    [onClose]
-  );
-
   const handleClose = useCallback(
     (event, reason) => {
       if (disableBackdropClick && reason === "backdropClick") return;
       if (disableEscapeKeyDown && reason === "escapeKeyDown") return;
 
-      onClose();
+      onClose(event, reason ? reason : "closeActionClick");
     },
     [disableBackdropClick, disableEscapeKeyDown, onClose]
   );
@@ -63,7 +58,7 @@ const DialogDisplay = ({
           size="small"
           className={classes.modalCloseButton}
           aria-label="Close"
-          onClick={handleActionClose}
+          onClick={handleClose}
         >
           <CloseIcon fontSize="small" />
         </IconButton>

--- a/components/DialogDisplay/DialogDisplay.js
+++ b/components/DialogDisplay/DialogDisplay.js
@@ -14,13 +14,37 @@ import cx from "classnames";
 
 const useStyles = makeStyles(dialogDisplayStyle);
 
-const DialogDisplay = ({ id, open, title, onClose, content, actions, overflowY, ...rest }) => {
+const DialogDisplay = ({
+  id,
+  open,
+  title,
+  onClose,
+  content,
+  actions,
+  overflowY,
+  disableBackdropClick,
+  disableEscapeKeyDown,
+  ...rest
+}) => {
   const classes = useStyles();
   const contentClasses = cx({
     [classes[overflowY]]: overflowY
   });
 
-  const handleActionClose = useCallback(event => onClose(event, 'closeActionClick'), [onClose])
+  const handleActionClose = useCallback(
+    event => onClose(event, "closeActionClick"),
+    [onClose]
+  );
+
+  const handleClose = useCallback(
+    (event, reason) => {
+      if (disableBackdropClick && reason === "backdropClick") return;
+      if (disableEscapeKeyDown && reason === "escapeKeyDown") return;
+
+      onClose();
+    },
+    [disableBackdropClick, disableEscapeKeyDown, onClose]
+  );
 
   return (
     <Dialog
@@ -28,7 +52,7 @@ const DialogDisplay = ({ id, open, title, onClose, content, actions, overflowY, 
         className: classes.paper
       }}
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       aria-labelledby={`${id}-dialog-display-title`}
       maxWidth="xl"
       {...rest}
@@ -53,8 +77,8 @@ const DialogDisplay = ({ id, open, title, onClose, content, actions, overflowY, 
 };
 
 DialogDisplay.defaultProps = {
-  overflowY: 'auto'
-}
+  overflowY: "auto"
+};
 
 DialogDisplay.propTypes = {
   /**
@@ -87,7 +111,15 @@ DialogDisplay.propTypes = {
   /**
    * The value of the overflowY CSS property
    */
-  overflowY: PropTypes.oneOf(["scroll", "hidden", "visible", "auto"])
+  overflowY: PropTypes.oneOf(["scroll", "hidden", "visible", "auto"]),
+  /**
+   * If true, clicking the backdrop will not fire the onClose callback.
+   */
+  disableBackdropClick: PropTypes.bool,
+  /**
+   * If true, hitting escape will not fire the onClose callback.
+   */
+  disableEscapeKeyDown: PropTypes.bool
 };
 
 export default DialogDisplay;


### PR DESCRIPTION
In the new version of material-UI, disableBackdropClick and disableEscapeKeyDown props are deprecated and must be implemented by users of the library, using the 'reason' argument to filter the 'backdropClick' and 'escapeKeyDown' events.