### PR TITLE
Make customInputProps deprecated + fix failing tests

### DIFF
--- a/__tests__/CustomTextField/CustomTextField.test.js
+++ b/__tests__/CustomTextField/CustomTextField.test.js
@@ -27,7 +27,7 @@ describe('CustomTextField', () => {
             label={'CustomTextField'}
             value={12 || ""}
             onChange={onCustomInputChange}
-            customInputProps={{
+            inputProps={{
                 decimalScale: 3,
                 thousandSeparator: true,
                 prefix: '$'

--- a/__tests__/PasswordField/PasswordField.test.js
+++ b/__tests__/PasswordField/PasswordField.test.js
@@ -34,10 +34,10 @@ describe("PasswordField", () => {
         showPasswordText="Show password text" />
     );
 
-    expect(wrapper.find(CustomTextField).props().customInputProps.type).toBe('password')
+    expect(wrapper.find(CustomTextField).props().inputProps.type).toBe('password')
 
     wrapper.find(IconButton).simulate('click');
 
-    expect(wrapper.find(CustomTextField).props().customInputProps.type).toBe('text')
+    expect(wrapper.find(CustomTextField).props().inputProps.type).toBe('text')
   });
 });

--- a/components/Autocomplete/Autocomplete.js
+++ b/components/Autocomplete/Autocomplete.js
@@ -145,7 +145,6 @@ const Autocomplete = ({
         <CustomTextField
           fullWidth
           {...params}
-          customInputProps={params.InputProps}
           startAdornment={params.InputProps.startAdornment}
           endAdornment={params.InputProps.endAdornment}
           {...textFieldProps}

--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { Button, makeStyles } from "@material-ui/core";
+import { Button, makeStyles, deprecatedPropType } from "@material-ui/core";
 import Tooltip from "../Tooltip/Tooltip";
 import buttonStyle from "./buttonStyle";
 

--- a/components/CustomTextField/CustomTextField.d.ts
+++ b/components/CustomTextField/CustomTextField.d.ts
@@ -44,13 +44,19 @@ export interface Props {
      */
     isNumeric?: boolean
     /**
-     * Other properties you can provide to the Input component.
+     * Other properties you can provide to the component.
+     * @deprecated Use `inputProps` instead.
      */
     customInputProps?: Object
     /**
      * Attributes applied to the input element.
+     * For the numeric input, you can provide properties like thousandSeparator, decimalScale and allowNegative.
      */
     inputProps?: Object
+    /**
+     * Other properties you can provide to the Input component.
+     */
+    InputProps?: Object
     /**
      * The short hint displayed in the input before the user enters a value.
      */

--- a/components/CustomTextField/CustomTextField.js
+++ b/components/CustomTextField/CustomTextField.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import NumberFormat from "react-number-format";
-import { makeStyles, TextField } from "@material-ui/core";
+import { makeStyles, TextField, deprecatedPropType } from "@material-ui/core";
 import textFieldStyle from "./textFieldStyle";
 import { useDebounce } from "use-debounce";
 import { curry } from "ramda";
@@ -81,6 +81,7 @@ function CustomTextField({
   isNumeric,
   customInputProps,
   inputProps,
+  InputProps,
   endAdornment,
   startAdornment,
   InputLabelProps,
@@ -97,13 +98,12 @@ function CustomTextField({
     ? {
         inputComponent: NumberFormatCustom,
         endAdornment,
-        startAdornment,
-        ...customInputProps
+        startAdornment
       }
     : {
         endAdornment,
         startAdornment,
-        ...customInputProps
+        ...InputProps
       };
 
   // attributes applied to the input element
@@ -164,13 +164,18 @@ CustomTextField.propTypes = {
    */
   isNumeric: PropTypes.bool,
   /**
-   * Other properties you can provide to the Input component.
+   * Other properties you can provide to the component.
    */
-  customInputProps: PropTypes.object,
+  customInputProps: deprecatedPropType(PropTypes.object, "Use `inputProps` instead."),
   /**
    * Attributes applied to the input element.
+   * For the numeric input, you can provide properties like thousandSeparator, decimalScale and allowNegative.
    */
   inputProps: PropTypes.object,
+  /**
+   * Other properties you can provide to the Input component.
+   */
+  InputProps: PropTypes.object,
   /**
    * End adornment of componenent. (Usually an InputAdornment from material-ui)
    */

--- a/components/PasswordField/PasswordField.js
+++ b/components/PasswordField/PasswordField.js
@@ -21,7 +21,7 @@ const PasswordField = ({ showPasswordText, hidePasswordText, ...rest }) => {
   return (
     <CustomTextField
       {...rest}
-      customInputProps={{
+      inputProps={{
         type: showPassword ? "text" : "password"
       }}
       endAdornment={


### PR DESCRIPTION
The prop customInputProps from CustomTextField is deprecated and should be replaced with inputProps in order to be aligned with the Material-UI names.
Fixed tests that were failing in the previous release.