### PR TITLE
Fix Autocomplete loadOptions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 @bit:registry=https://node.bit.dev/
-//node.bit.dev/:_authToken=${BIT_TOKEN}
-always-auth=true

--- a/components/Autocomplete/Autocomplete.js
+++ b/components/Autocomplete/Autocomplete.js
@@ -121,7 +121,7 @@ const Autocomplete = ({
   );
 
   const handleOpen = useCallback(() => {
-    if (loadOptions && options.length === (length(defaultOptions) || 0))
+    if (loadOptions)
       loadOptions().then(loadedOptions => {
         setOptions(loadedOptions || emptyArray);
       });


### PR DESCRIPTION
Previously, loadOptions was called only if the options array was empty. 
We need to call it anyway, because sometimes the queries may depend on variables that change their values.