### PR TITLE
SimpleSlider decimalScale bugfix and thousandSeparator inclusion

### DIFF
--- a/components/SimpleSlider/SimpleSlider.d.ts
+++ b/components/SimpleSlider/SimpleSlider.d.ts
@@ -69,7 +69,7 @@ export interface Props {
     decimalScale?: number;
   
     /**
-    * Add thousand separators on number; single character string or boolean true
+    * Add thousand separators on number; single character string or boolean true (true is default to ,)
     */
     thousandSeparator?: boolean | string;
 

--- a/components/SimpleSlider/SimpleSlider.d.ts
+++ b/components/SimpleSlider/SimpleSlider.d.ts
@@ -67,6 +67,11 @@ export interface Props {
      * number of decimals to be displayed
      */
     decimalScale?: number;
+  
+    /**
+    * Add thousand separators on number; single character string or boolean true
+    */
+    thousandSeparator?: boolean | string;
 
     /**
      * If true, the slider will be disabled

--- a/components/SimpleSlider/SimpleSlider.js
+++ b/components/SimpleSlider/SimpleSlider.js
@@ -11,7 +11,7 @@ import simpleSliderStyle from "./simpleSliderStyle";
 const useStyles = makeStyles(simpleSliderStyle);
 
 const SimpleSlider = ({ label, fullWidth, value, min, max, step, onChange, error,
-    helperText, required, decimalScale, disabled, showSliderLimits, ...other }) => {
+    helperText, required, decimalScale, thousandSeparator, disabled, showSliderLimits, ...other }) => {
     const classes = useStyles();
 
     const onTextChanged = useCallback(event => {
@@ -41,7 +41,8 @@ const SimpleSlider = ({ label, fullWidth, value, min, max, step, onChange, error
                 required={required}
                 value={value}
                 onChange={OnTextChangedDebounced}
-                inputProps={{ decimalScale: decimalScale }}
+                isNumeric={true}
+                inputProps={{ decimalScale: decimalScale, thousandSeparator: thousandSeparator }}
                 disabled={disabled}
             />
 
@@ -79,6 +80,7 @@ SimpleSlider.propTypes = {
     helperText: PropTypes.string,
     required: PropTypes.bool,
     decimalScale: PropTypes.number,
+    thousandSeparator: PropTypes.bool,
     disabled: PropTypes.bool,
     showSliderLimits: PropTypes.bool
 };

--- a/components/SimpleSlider/SimpleSlider.js
+++ b/components/SimpleSlider/SimpleSlider.js
@@ -80,7 +80,7 @@ SimpleSlider.propTypes = {
     helperText: PropTypes.string,
     required: PropTypes.bool,
     decimalScale: PropTypes.number,
-    thousandSeparator: PropTypes.bool,
+    thousandSeparator: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     disabled: PropTypes.bool,
     showSliderLimits: PropTypes.bool
 };


### PR DESCRIPTION
When using SimpleSlider CustomTextField should be numeric.
![image](https://user-images.githubusercontent.com/40171259/133402096-0429dcda-b822-43f8-804d-44b9344af057.png)
