### PR TITLE
[Autocomplete] Display loading state

### DIFF
--- a/components/Autocomplete/Autocomplete.d.ts
+++ b/components/Autocomplete/Autocomplete.d.ts
@@ -31,9 +31,13 @@ export interface AutocompleteProps {
    */
   onInputChange?: (event: React.SyntheticEvent, value: string, reason: string) => void;
   /**
-   * Handle the menu opening.
+   * Handles the menu opening.
    */
   onMenuOpen?: () => void
+  /**
+   * Handles the menu closing.
+   */
+  onClose?: () => void
   /**
    * @default false  
    * If true, the user can select multiple values from list.


### PR DESCRIPTION
While the options are loading, the Autocomplete will display a spinner in it's input field and a 'Loading...' message in the options dialog.
The message can be customized by through the loadingText prop.

Closes #117 