### PR TITLE
Change opacity for disabled button

### DIFF
--- a/assets/jss/styles.js
+++ b/assets/jss/styles.js
@@ -636,7 +636,7 @@ const styles = theme => {
       }
     },
     disabled: {
-      opacity: "0.65",
+      opacity: "0.5",
       pointerEvents: "none",
       backgroundColor: grayColor,
       color: whiteColor,


### PR DESCRIPTION
Change opacity for disabled button. The opacity is now 0.5, in order to comply with material-ui standards.