### PR TITLE
[Autocomplete] Fixes and refactor

### DIFF
--- a/components/Autocomplete/Option.js
+++ b/components/Autocomplete/Option.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState, useRef } from 'react'
+import PropTypes from 'prop-types'
+import { Checkbox, Tooltip, makeStyles } from '@material-ui/core'
+import { CheckBox, CheckBoxOutlineBlank } from '@material-ui/icons'
+import Typography from '../Typography'
+import autoCompleteStyle from './autocompleteStyle'
+
+const useStyles = makeStyles(autoCompleteStyle)
+
+const Option = ({ optionLabel, createdLabel, selected, withCheckboxes }) => {
+  const classes = useStyles()
+
+  const optionRef = useRef(null)
+  const [isOverflow, setIsOverflow] = useState(false)
+
+  const label = createdLabel ? `${createdLabel} "${optionLabel}"` : optionLabel
+
+  useEffect(() => {
+    setIsOverflow(optionRef?.current?.scrollWidth > optionRef?.current?.clientWidth)
+  }, [])
+
+  return withCheckboxes ? (
+    <>
+      <Checkbox
+        icon={<CheckBoxOutlineBlank fontSize='small' />}
+        checkedIcon={<CheckBox fontSize='small' />}
+        style={{ marginRight: 8 }}
+        checked={selected}
+      />
+      {optionLabel}
+    </>
+  ) : (
+    <Tooltip title={optionLabel} disableHoverListener={!isOverflow}>
+        <div ref={optionRef} className={classes.option}>
+          <Typography>{label}</Typography>
+        </div>
+    </Tooltip>
+  )
+}
+
+Option.propTypes = {
+  optionLabel: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  withCheckboxes: PropTypes.bool,
+  createdLabel: PropTypes.string
+}
+
+export default Option

--- a/components/Autocomplete/utils.js
+++ b/components/Autocomplete/utils.js
@@ -1,0 +1,56 @@
+import { createFilterOptions } from '@material-ui/lab/Autocomplete'
+import { prop, map, innerJoin, find, propEq, all, includes, is, isEmpty, isNil, props, omit } from 'ramda'
+import { emptyArray } from '../../utils/constants'
+
+export const findFirstNotNil = (propNames, option) => find(x => !isNil(x), props(propNames, option))
+export const isStringOrNumber = option => is(String, option) || is(Number, option)
+
+const hasStringOptions = options => all(is(String), options) && !isEmpty(options)
+
+const filter = createFilterOptions()
+export const filterOptions = (labelKey, valueKey, creatable) => (options, params) => {
+  const filtered = filter(options, params)
+  const { inputValue } = params
+
+  // Suggest the creation of a new value if it's not empty and it doesn't already exist
+  if (creatable && inputValue !== '' && !find(propEq(labelKey, inputValue), options)) {
+    filtered.push(
+      hasStringOptions(options)
+        ? {
+            _primitiveValue: inputValue,
+            _createdOption: true
+          }
+        : {
+            [valueKey]: inputValue,
+            [labelKey]: inputValue,
+            _createdOption: true
+          }
+    )
+  }
+
+  return filtered
+}
+
+export const getSimpleValue = (options, value, valueKey, isMultiSelection) => {
+  if (isMultiSelection && (!is(Array, value) || isEmpty(options))) return emptyArray
+  if (!all(is(Object), options)) return value
+
+  // Add new options if the Autocomplete is multiSelection and creatable
+  if (is(Array, value)) {
+    const optionsSimpleValues = map(prop(valueKey), options)
+    value?.map(v => {
+      if (!includes(v, optionsSimpleValues)) options.push({ [valueKey]: v })
+    })
+  }
+
+  const result = isMultiSelection ? innerJoin((o, v) => o[valueKey] === v, options, value) : find(propEq(valueKey, value), options)
+  return result || null
+}
+
+export const computeChangedMultiValue = (input, simpleValue, valueKey, labelKey) =>
+  simpleValue
+    ? input.map(a => (is(String, a) ? a : findFirstNotNil([valueKey, labelKey, '_primitiveValue'], a)))
+    : input.map(a => (is(String, a) ? a : prop('_primitiveValue', a) || omit(['_createdOption'], a)))
+
+export const computeChangedSingleValue = (input, simpleValue, valueKey, labelKey) =>
+  simpleValue ? findFirstNotNil([valueKey, labelKey], input) : prop('_primitiveValue', input) ?? omit(['_createdOption'], input)


### PR DESCRIPTION
Fix bugs in creatable and async Autocomplete
Refactor code

IMPORTANT: Autocomplete that is at the same time **multi-option, creatable and simple value** doesn't work due to a bug in Material-UI v4 that gets fixed in v5. To use this kind of Autocomplete, migrate to the new rocket components library (to be released soon).